### PR TITLE
Prevents a crash when embedding label in a designable view

### DIFF
--- a/LTMorphingLabel/LTMorphingLabel.swift
+++ b/LTMorphingLabel/LTMorphingLabel.swift
@@ -107,7 +107,7 @@ typealias LTMorphingSkipFramesClosure = (Void) -> Int
 
 
 // MARK: - LTMorphingLabel
-public class LTMorphingLabel: UILabel {
+@IBDesignable public class LTMorphingLabel: UILabel {
     
     public var morphingProgress: Float = 0.0
     public var morphingDuration: Float = 0.6
@@ -137,7 +137,11 @@ public class LTMorphingLabel: UILabel {
         return super.text
     }
     set {
+#if TARGET_INTERFACE_BUILDER
+        _originText = newValue ?? ""
+#else
         _originText = text ?? ""
+#endif
         _diffResults = _originText >> newValue
         super.text = newValue ?? ""
         
@@ -146,7 +150,8 @@ public class LTMorphingLabel: UILabel {
         _totalFrames = 0
         
         self.setNeedsLayout()
-        
+ 
+#if !TARGET_INTERFACE_BUILDER
         if _originText != text {
             displayLink.paused = false
             if let closure = _startClosures["\(morphingEffect.description)\(LTMorphingPhaseStart)"] {
@@ -157,6 +162,7 @@ public class LTMorphingLabel: UILabel {
                 didStart(self)
             }
         }
+#endif
     }
     }
     


### PR DESCRIPTION
I really like the label, but it keeps crashing the IBDesignables agent when it is programmatically embed it inside an IBDesignable view.  The problem is that the IBDesignables agent can't instantiate a display link object to animate the change from empty to whatever other text one provides.  Here, I've made 3 changes to get the label to work:

1) Added the designable tag to the class
2) Made the animation conditional on the target not being the IB agent.  This prevents the above issue with the display link.
3) Forced the _originText to the new value for the IB agent.  This is necessary to get the label to draw the characters correctly. If the value isn't set, then without the animation, the label will be blank (it's previous value).

I think this is the minimal change required to get the designables behavior, but it might not be the cleanest.
