### PR TITLE
Automatically demonstrate the effect when the segment changes

### DIFF
--- a/LTMorphingLabelDemo/LTDemoViewController.swift
+++ b/LTMorphingLabelDemo/LTDemoViewController.swift
@@ -55,6 +55,8 @@ class LTDemoViewController: UIViewController, LTMorphingLabelDelegate {
         default:
             self.label.morphingEffect = .Scale
         }
+        
+        self.changeText(sender);
     }
 
     @IBAction func toggleLight(sender: UISegmentedControl) {


### PR DESCRIPTION
Only clicking the label will trigger the effect. It makes sense to me to show the effect automatically whenever a new segment is selected.
