### PR TITLE
Fix label not paying attention to iOS 8.2 and later font weights.

### DIFF
--- a/LTMorphingLabel/LTMorphingLabel.swift
+++ b/LTMorphingLabel/LTMorphingLabel.swift
@@ -434,7 +434,7 @@ extension LTMorphingLabel {
                 let s = String(charLimbo.char)
                 s.drawInRect(charRect, withAttributes: [
                     NSFontAttributeName:
-                        font.fontWithSize(charLimbo.size),
+                        UIFont.init(name: font.fontName, size: charLimbo.size)!,
                     NSForegroundColorAttributeName:
                         textColor.colorWithAlphaComponent(charLimbo.alpha)
                     ])

--- a/LTMorphingLabelDemo/LTDemoViewController.swift
+++ b/LTMorphingLabelDemo/LTDemoViewController.swift
@@ -73,7 +73,7 @@ class LTDemoViewController : UIViewController, LTMorphingLabelDelegate {
     }
     
     @IBAction func changeFontSize(sender: UISlider) {
-        label.font = label.font.fontWithSize(CGFloat(sender.value))
+        label.font = UIFont.init(name: label.font.fontName, size: CGFloat(sender.value))
         label.text = label.text
         label.setNeedsDisplay()
     }


### PR DESCRIPTION
From iOS 8.2 onwards, UIFont allows you to specify a font weight. For example:

`label.font = UIFont.systemFontOfSize(28, weight: UIFontWeightUltraLight)`

I was using this in my app and noticed that LTMorphingLabel didn't pay any attention to the weight set on the font. This change fixes this by creating the UIFont object from name, as `fontWithSize` seems to ignore weights and the name returns the weighted font name.

You can test this behaviour by putting the first code example in this pull request in `viewDidLoad()` in `LTDemoViewController` — without the change the font will have normal weight.