### PR TITLE
Fix animation stop problem. It happen for duplicate text set call

### DIFF
--- a/LTMorphingLabel/LTMorphingLabel.swift
+++ b/LTMorphingLabel/LTMorphingLabel.swift
@@ -100,6 +100,8 @@ typealias LTMorphingSkipFramesClosure =
             return super.text
         }
         set {
+            guard text != newValue else { return }
+
             previousText = text ?? ""
             diffResults = previousText >> (newValue ?? "")
             super.text = newValue ?? ""


### PR DESCRIPTION
When I set the same text before the animation is finished, it will stop.

```swift
morphingLabel.text = "aaa"
morphingLabel.text = "aaa" // Drawing text is in progress. But CADisplayLink stopped
```

I think this is an unintended behavior. I have been fix it.