### PR TITLE
Fix initial text is not displayed problem.

### DIFF
--- a/LTMorphingLabel/LTMorphingLabel.swift
+++ b/LTMorphingLabel/LTMorphingLabel.swift
@@ -415,7 +415,7 @@ extension LTMorphingLabel {
     }
     
     override public func drawTextInRect(rect: CGRect) {
-        if !morphingEnabled {
+        if !morphingEnabled || limboOfCharacters().count == 0 {
             super.drawTextInRect(rect)
             return
         }


### PR DESCRIPTION
I love LTMorphingLabel and often use, but initial text is not displayed When I set in storyboard.

<img width="354" alt="sample_screenshot1" src="https://cloud.githubusercontent.com/assets/15372425/16075052/348fb9a8-3328-11e6-83c8-d248e8b6bfde.png">

![sample_screenshot2](https://cloud.githubusercontent.com/assets/15372425/16075132/83d9c350-3328-11e6-80b2-768e6a8c5c5e.png)

So I have fixed it.