### PR TITLE
Fix changing text without animation (allow enable/disable)

### DIFF
--- a/LTMorphingLabel/LTMorphingLabel.swift
+++ b/LTMorphingLabel/LTMorphingLabel.swift
@@ -103,6 +103,8 @@ typealias LTMorphingSkipFramesClosure =
     var charHeight: CGFloat = 0.0
     var skipFramesCount: Int = 0
     
+    private var tempRenderMorphingEnabled = true
+    
     #if TARGET_INTERFACE_BUILDER
     let presentingInIB = true
     #else
@@ -134,6 +136,7 @@ typealias LTMorphingSkipFramesClosure =
             currentFrame = 0
             totalFrames = 0
             
+            tempRenderMorphingEnabled = morphingEnabled
             setNeedsLayout()
             
             if !morphingEnabled {
@@ -479,7 +482,7 @@ extension LTMorphingLabel {
     }
     
     override open func drawText(in rect: CGRect) {
-        if !morphingEnabled || limboOfCharacters().count == 0 {
+        if !tempRenderMorphingEnabled || limboOfCharacters().count == 0 {
             super.drawText(in: rect)
             return
         }


### PR DESCRIPTION
Changing attribute `morphingEnabled` while a animation cause stopping them on half a way.
See example: #60.

The changes will use the enabled state of text change to running out current animation.