### PR TITLE
Update project SWIFT_VERSION to 4.2 for Fix Swift 4.2 build error.

### DIFF
--- a/LTMorphingLabelDemo.xcodeproj/project.pbxproj
+++ b/LTMorphingLabelDemo.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = "";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -886,7 +886,7 @@
 				METAL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = "";
+				SWIFT_VERSION = 4.2;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
What happened:
When using this library with CocoaPods, Swift Version of the build target is specified as 4.0 and an error occurs.
Approach:
Resolve Swift Version by specifying 4.2 for the entire project.