### PR TITLE
Simplifies easeOutQuint by using pow instead of $0 * $0 for 5 times.

### DIFF
--- a/LTMorphingLabel/LTEasing.swift
+++ b/LTMorphingLabel/LTEasing.swift
@@ -18,7 +18,7 @@ public struct LTEasing {
     
     public static func easeOutQuint(_ t: Float, _ b: Float, _ c: Float, _ d: Float = 1.0) -> Float {
         return {
-            return c * ($0 * $0 * $0 * $0 * $0 + 1.0) + b
+            return c * (pow($0, 5) + 1.0) + b
             }(t / d - 1.0)
     }
     


### PR DESCRIPTION
While I was compiling LTMorphingLabel as a carthage dependency on CircleCI (using Swift 5), I had an error on this line:
`The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions`

By using `pow`, I made the expression a bit simpler but with the same meaning.