### PR TITLE
Use fontDescriptor instead of fontName to load UIFont

### DIFF
--- a/LTMorphingLabel/LTMorphingLabel.swift
+++ b/LTMorphingLabel/LTMorphingLabel.swift
@@ -535,9 +535,7 @@ extension LTMorphingLabel {
                     .foregroundColor: textColor.withAlphaComponent(charLimbo.alpha)
                 ]
 
-                if let font = UIFont(name: font.fontName, size: charLimbo.size) {
-                    attrs[.font] = font
-                }
+                attrs[.font] = UIFont(descriptor: font.fontDescriptor, size: charLimbo.size)
                 
                 for (key, value) in textAttributes ?? [:] {
                     attrs[key] = value

--- a/LTMorphingLabelDemo/LTDemoViewController.swift
+++ b/LTMorphingLabelDemo/LTDemoViewController.swift
@@ -84,7 +84,7 @@ class LTDemoViewController : UIViewController, LTMorphingLabelDelegate {
     }
     
     @IBAction func changeFontSize(_ sender: UISlider) {
-        label.font = UIFont.init(name: label.font.fontName, size: CGFloat(sender.value))
+        label.font = UIFont(descriptor: label.font.fontDescriptor, size: CGFloat(sender.value))
         label.text = label.text
     }
 }


### PR DESCRIPTION
Fixes https://github.com/lexrus/LTMorphingLabel/issues/130