### PR TITLE
Fixed the problem that MorphingText could not be found when installed via CocoaPods

### DIFF
--- a/LTMorphingLabel.podspec
+++ b/LTMorphingLabel.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
                     :git => "https://github.com/lexrus/LTMorphingLabel.git",
                     :tag => s.version
                    }
-  s.source_files = "LTMorphingLabel/*.{h,swift}"
+  s.source_files = "LTMorphingLabel/*.{h,swift}", "LTMorphingLabel/**/*.{swift}"
   s.resources    = "LTMorphingLabel/Particles/*.png"
   s.frameworks   = "UIKit", "Foundation", "QuartzCore"
   s.requires_arc = true


### PR DESCRIPTION
When MorphingText is installed via CocoaPods, the SwiftUI project cannot find the class `MorphingText` because the rules of the podspec file do not scan the `MorphingText.swift` file in the SwiftUI directory.